### PR TITLE
security-crypto:1.1.0-alpha02へ更新

### DIFF
--- a/SecuritySample/app/build.gradle
+++ b/SecuritySample/app/build.gradle
@@ -51,5 +51,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // セキュリティ
-    implementation "androidx.security:security-crypto:1.0.0-rc01"
+    implementation "androidx.security:security-crypto:1.1.0-alpha02"
 }


### PR DESCRIPTION
## 概要

- security-crypto:1.1.0-alpha02へ更新
- MasterKeysがdeprecatedになったので対応

`Masterkeys`を使わない方法でMasterkeysを使って暗号化したファイルを復号化できることを確認済み。

## 備考
`MasterKeysがdeprecatedになったので対応`はFirstFragmentで復号化`readEncryptedFile()`のみ。
MasterKeysがdeprecatedになってどのように修正するのが正しいのか試行錯誤しながら、まずは1箇所のみ試したかったため。